### PR TITLE
Create an index function

### DIFF
--- a/pttdm.py
+++ b/pttdm.py
@@ -280,6 +280,14 @@ def print_func_result(func):
     print "--- Result end ---"
 
 
+def index():
+    r = ""
+    for k, v in slides.iteritems():
+        doc = inspect.getdoc(v[0])
+        if doc is not None and k.isdigit():
+            r += "{}: {}\n".format(k, doc.split('\n')[0])
+    return r
+
 def exit():
     sys.exit(0)
 
@@ -330,10 +338,8 @@ if __name__ == "__main__":
                     print_func_result(func)
                     sys.stdin.readline()
             else:
-                print "Slide '{0}' not found. Available_slides: {1}".format(
-                    user_input,
-                    sorted(slides.keys())
-                )
+                print "Slide '{0}' not found. Available_slides:\n{1}".format(
+                    user_input, index())
         except Exception:
             raise
         except:

--- a/pttdm.py
+++ b/pttdm.py
@@ -259,6 +259,7 @@ def questions():
     http://sahandsaba.com/thirty-python-language-features-and-tricks-you-may-not-know.html
     """
 
+
 def end():
     """ Thank you all!
 
@@ -287,6 +288,7 @@ def index():
         if doc is not None and k.isdigit():
             r += "{}: {}\n".format(k, doc.split('\n')[0])
     return r
+
 
 def exit():
     sys.exit(0)

--- a/pttdm.py
+++ b/pttdm.py
@@ -283,8 +283,8 @@ def print_func_result(func):
 
 def index():
     r = ""
-    for k, v in slides.iteritems():
-        doc = inspect.getdoc(v[0])
+    for k in sorted(slides, key=slides.get):
+        doc = inspect.getdoc(slides[k][0])
         if doc is not None and k.isdigit():
             r += "{}: {}\n".format(k, doc.split('\n')[0])
     return r


### PR DESCRIPTION
That shows the first line of the docstring so the result of selecting an invalid slide shows:

```
itorres@dawn:~/src/3rd/jsoucheiron$ python pybcn-talk-pttdm/pttdm.py 
Slide(start):
i
Slide 'i' not found. Available_slides:
1: This dictionary constructions are very usual,
2: Lists offer a wide variety of ways of accessing its elements.
3: Advanced "and" and "or" usage.
4: Default arguments are only evaluated once
5: Unpacking
6: Exceptions
7: Full try/except/else/finally flow
8: Other unpacking tricks:
9: Chaining comparisons
10: In order to start a web file server on

Slide(start):
exit

```
